### PR TITLE
Notion #22 - Auto Release & Versioning (workflows)

### DIFF
--- a/.github/workflows/unity_builder.yaml
+++ b/.github/workflows/unity_builder.yaml
@@ -95,8 +95,58 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}
 
+  testRunner:
+    needs:
+      - checkLicense
+      - build
+    strategy:
+      matrix:
+        targetPlatform:
+          # The target platform to build the project for.
+          # Need to add more platform if the project need to be built for more platform.
+          # Example : StandaloneOSX, StandaloneLinux64, WebGL, iOS, Android, etc...
+          - StandaloneWindows64
+    name: Test all modes 🧪
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Create LFS file list
+        run: git lfs ls-files | cut -d ' ' -f1 | sort > .lfs-asset-id
+      - name: Restore LFS cache
+        uses: actions/cache@v2
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-asset-id') }}
+      - name: Git LFS pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+      - name: Restore library cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.projectPath }}/Library
+          key: Library-${{ env.projectPath }}-{{ $matrix.targetPlatform }}
+          restore-keys: |
+            Library-${{ env.projectPath }}-
+            Library-
+      - name: Run Test
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ env.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ env.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ env.UNITY_PASSWORD }}
+        with:
+          projectPath: ${{ env.projectPath }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          customImage: ${{ env.dockerImage }}
+
   release:
-    needs: build
+    needs:
+      - build
+      - testRunner
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -145,51 +195,3 @@ jobs:
             build/Release.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  testRunner:
-    needs:
-      - checkLicense
-      - build
-    strategy:
-      matrix:
-        targetPlatform:
-          # The target platform to build the project for.
-          # Need to add more platform if the project need to be built for more platform.
-          # Example : StandaloneOSX, StandaloneLinux64, WebGL, iOS, Android, etc...
-          - StandaloneWindows64
-    name: Test all modes 🧪
-    runs-on: windows-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Create LFS file list
-        run: git lfs ls-files | cut -d ' ' -f1 | sort > .lfs-asset-id
-      - name: Restore LFS cache
-        uses: actions/cache@v2
-        id: lfs-cache
-        with:
-          path: .git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-asset-id') }}
-      - name: Git LFS pull
-        run: |
-          git lfs pull
-          git add .
-          git reset --hard
-      - name: Restore library cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.projectPath }}/Library
-          key: Library-${{ env.projectPath }}-{{ $matrix.targetPlatform }}
-          restore-keys: |
-            Library-${{ env.projectPath }}-
-            Library-
-      - name: Run Test
-        uses: game-ci/unity-test-runner@v4
-        env:
-          UNITY_LICENSE: ${{ env.UNITY_LICENSE }}
-          UNITY_EMAIL: ${{ env.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ env.UNITY_PASSWORD }}
-        with:
-          projectPath: ${{ env.projectPath }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          customImage: ${{ env.dockerImage }}

--- a/.github/workflows/unity_builder.yaml
+++ b/.github/workflows/unity_builder.yaml
@@ -5,10 +5,10 @@ name: Check if Unity Project build correctly🔨
 # The result of the build can be found in the artifacts of the workflow.
 
 on:
-  # Work only on pull request with any branches
-  pull_request:
+  # Work only when we push on the main branch
+  push:
     branches:
-      - '**'
+      - main
   workflow_dispatch:
 
 env:
@@ -76,6 +76,9 @@ jobs:
             Library-${{ env.projectPath }}-
             Library-
       - name: Build project
+        # This step can failed if the Library folder is exacly the same as the cache.
+        # It will say:
+        # - Error: Branch is dirty. Refusing to base semantic version on uncommitted changes
         uses: game-ci/unity-builder@v4.2.3
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -91,6 +94,58 @@ jobs:
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        targetPlatform:
+          # The target platform to build the project for.
+          # Need to add more platform if the project need to be built for more platform.
+          # Example : StandaloneOSX, StandaloneLinux64, WebGL, iOS, Android, etc...
+          - StandaloneWindows64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Get last commit message
+        id: get_commit_message
+        run: |
+          LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          echo "LAST_COMMIT_MESSAGE=${LAST_COMMIT_MESSAGE//$'\n'/\\n}" >> $GITHUB_ENV
+      - name: Extract version from commit message
+        id: version
+        run: |
+          TAG=$(echo "${{ env.LAST_COMMIT_MESSAGE }}" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+)?')
+          echo "Extracted TAG: $TAG"
+          if [ -z "$TAG" ]; then
+            echo "No valid tag found in the commit message."
+            exit 1
+          fi
+          TAG="v$TAG"  # Ajoute le préfixe 'v'
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          path: build
+      - name: List files in build directory # Debug for showing all the files that contains the Unity build.
+        run: ls -R build
+        shell: pwsh
+      - name: Create a ZIP of the build folder
+        run: |
+          zip -r build/Release.zip build/Build-${{ matrix.targetPlatform }}/*
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.TAG }}
+          body: 'Auto-generated release'
+          files: |
+            build/Release.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   testRunner:
     needs:
       - checkLicense


### PR DESCRIPTION
## Pull Request

### Description

In this feature we upgrade our old workflows [unity_builder.yaml](https://github.com/EnzoGrn/Vermines/blob/dev/.github/workflows/unity_builder.yaml).
Now this workflow can create release automatically.
He can now only be played if we push on main from a branch that have a name as 'release-1.0.0' for example.
Some debug comes like display all files contains in build directory of artifacts.
When the workflow success, you can go in the Releases part of the repository and see you new release with a 'Release.zip' files that contains all build of our projects in all version like 'Windows, Linux, Xbox...). 

### Related Issue(s)
[Notion #23](https://www.notion.so/Github-Action-Auto-Release-Versioning-10955ef261d880519eebdd2c1795d20d)

### Changes Made
Debug print in build directory.
Auto release steps in the workflows just after build and test runner successfully done.

### Testing
Test in a custom repository with a Test Unity Project, and trying to create some Release.

### Screenshots (if applicable)
![Capture d’écran 2024-10-03 141854](https://github.com/user-attachments/assets/cc2504b6-c7a3-4f5c-bb27-fae1a872601f)
(![Capture d’écran 2024-10-03 141751](https://github.com/user-attachments/assets/c969f645-19fe-41ed-a1e1-6dbf58f864ac))

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Additional Notes
The documentation of this workflows can be found here in [Notions](https://www.notion.so/Unity-10c55ef261d8806e9c1dd4f7700decd7).

### Definition of Done
- Auto Release & Versioning work correctly
- All workflows steps past the test and run successfully
- Documentation has been written