### PR TITLE
 Notion #27 - Mirror repository

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -1,0 +1,27 @@
+name: Mirroring
+on:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows: ["Check if Unity Project build correctly🔨"]
+    types:
+      - completed 
+
+env:
+  MIRROR_URL:
+    git@github.com:EpitechPromo2026/G-EIP-700-REN-7-1-eip-enzo.garnier.git
+
+jobs:
+  mirroring:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url:
+            ${{ env.MIRROR_URL }}
+          ssh_private_key:
+            ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Pull Request

### Description
Add github action to mirror this repository on the Epitech repository when there is a push on main.

### Related Issue(s)
[Notion #27](https://www.notion.so/Migrer-sous-github-project-mirroring-10e55ef261d880218a81fdce27ff32b2?pvs=4)

### Changes Made
Added a new GitHub Action:
- Created a GitHub Action to automatically mirror this repository on the remote Epitech repository.
- The action triggers when a new push is done on main, after the unity build workflow.

### Testing
Test in two custom repositories, and trying to mirror.

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/44b59dee-3302-4007-a296-0b1097270a38)
![image](https://github.com/user-attachments/assets/eb2c88a8-9ee9-41a6-b9d4-61d920688ba1)
![image](https://github.com/user-attachments/assets/af7354df-1ef2-4814-a274-9095a5808c70)

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.
- [x] I have added secrets variables

### Definition of Done
- This repository can be mirror successfully
- All workflows steps past the test and run successfully