### PR TITLE
Issue #21 - Lobby: fix join room

### DIFF
--- a/Vermines/Assets/Scripts/Network/Lobby/ALobbyManager.cs
+++ b/Vermines/Assets/Scripts/Network/Lobby/ALobbyManager.cs
@@ -27,6 +27,7 @@ public abstract class ALobbyManager : MonoBehaviour
 
         _networkLobbyManagerPrefab.OnJoinedLobbyAction += OnClientConnectedToServer;
         _networkLobbyManagerPrefab.OnDisconnectedAction += OnClientDisconnectedFromServer;
+        _networkLobbyManagerPrefab.OnJoinRoomFailedAction += OnJoinRoomFailed;
     }
 
     #region Callbacks
@@ -52,6 +53,11 @@ public abstract class ALobbyManager : MonoBehaviour
     {
         Debug.Log("Client disconnected to server");
     }
+
+    public virtual void OnJoinRoomFailed()
+    {
+        Debug.Log("Client left lobby");
+    }
     #endregion
 
     /*
@@ -66,5 +72,6 @@ public abstract class ALobbyManager : MonoBehaviour
     {
         _networkLobbyManagerPrefab.OnJoinedLobbyAction -= OnClientConnectedToServer;
         _networkLobbyManagerPrefab.OnDisconnectedAction -= OnClientDisconnectedFromServer;
+        _networkLobbyManagerPrefab.OnJoinRoomFailedAction -= OnJoinRoomFailed;
     }
 }

--- a/Vermines/Assets/Scripts/Network/Lobby/NetworkLobbyManager.cs
+++ b/Vermines/Assets/Scripts/Network/Lobby/NetworkLobbyManager.cs
@@ -20,6 +20,11 @@ public class NetworkLobbyManager : MonoBehaviourPunCallbacks
      * @brief This event is triggered when the client has disconnected from the server.
      */
     public event Action OnDisconnectedAction;
+
+    /*
+     * @brief This event is triggered when the client failed to join a room.
+     */
+    public event Action OnJoinRoomFailedAction;
     #endregion
 
 
@@ -33,6 +38,9 @@ public class NetworkLobbyManager : MonoBehaviourPunCallbacks
      */
     public void ConnectClientToServer()
     {
+        // Remove in the future: actually here for purpose test
+        PhotonNetwork.PhotonServerSettings.AppSettings.FixedRegion = "jp";
+
         if (PhotonNetwork.IsConnectedAndReady)
         {
             Debug.Log("Client already connected to master server");
@@ -110,5 +118,18 @@ public class NetworkLobbyManager : MonoBehaviourPunCallbacks
         Debug.Log(cause.ToString());
         OnDisconnectedAction?.Invoke();
     }
+
+    public override void OnJoinRoomFailed(short returnCode, string message)
+    {
+        Debug.Log("Join room failed : " + message);
+
+        // When fail to join a room Pun2 seems disconnect the client from the lobby.
+        if (!PhotonNetwork.InLobby)
+        {
+            Debug.Log("Client not in a lobby");
+            ConnectToLobby();
+        }
+    }
+
     #endregion
 }

--- a/Vermines/Assets/Scripts/Network/Room/NetworkRoomManager.cs
+++ b/Vermines/Assets/Scripts/Network/Room/NetworkRoomManager.cs
@@ -58,9 +58,31 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
      */
     public void CreatePrivateRoom(string roomCode = "", bool isVisible = false, int maxPLayers = 2)
     {
-        if (!PhotonNetwork.IsConnectedAndReady || !PhotonNetwork.InLobby || PhotonNetwork.InRoom)
+        if (!PhotonNetwork.IsConnected)
         {
-            OnCreateRoomFailed(0, "Client not connected or already in a room !");
+            OnCreateRoomFailed(0, "Client not connected to master server");
+            Debug.Log("Client not connected to master server");
+            return;
+        }
+
+        if (!PhotonNetwork.IsConnectedAndReady)
+        {
+            OnCreateRoomFailed(0, "Client may not be ready");
+            Debug.Log("Client may not be ready");
+            return;
+        }
+
+        if (!PhotonNetwork.InLobby)
+        {
+            OnCreateRoomFailed(0, "Client not in lobby");
+            Debug.Log("Client not in lobby");
+            return;
+        }
+
+        if (PhotonNetwork.InRoom)
+        {
+            OnCreateRoomFailed(0, "Client already in a room");
+            Debug.Log("Client already in a room");
             return;
         }
 
@@ -85,9 +107,38 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
      */
     public void JoinPrivateRoom(string roomCode)
     {
-        if (!PhotonNetwork.IsConnectedAndReady || !PhotonNetwork.InLobby || PhotonNetwork.InRoom || string.IsNullOrEmpty(roomCode))
+        if (string.IsNullOrEmpty(roomCode))
         {
-            OnJoinRoomFailed(0, "Client not connected or already in a room !");
+            OnJoinRoomFailed(0, "Room code is empty");
+            Debug.Log("Room code is empty");
+            return;
+        }
+
+        if (!PhotonNetwork.IsConnected)
+        {
+            OnJoinRoomFailed(0, "Client not connected to master server");
+            Debug.Log("Client not connected to master server");
+            return;
+        }
+
+        if (!PhotonNetwork.IsConnectedAndReady)
+        {
+            OnJoinRoomFailed(0, "Client may not be ready");
+            Debug.Log("Client may not be ready");
+            return;
+        }
+
+        if (!PhotonNetwork.InLobby)
+        {
+            OnJoinRoomFailed(0, "Client not in lobby");
+            Debug.Log("Client not in lobby");
+            return;
+        }
+
+        if (PhotonNetwork.InRoom)
+        {
+            OnJoinRoomFailed(0, "Client already in a room");
+            Debug.Log("Client already in a room");
             return;
         }
 
@@ -138,7 +189,7 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
 
     public override void OnJoinRoomFailed(short returnCode, string message)
     {
-        Debug.Log(message);
+        Debug.Log($"JoinRoomFailed: {message} (Return Code: {returnCode})");
         OnJoinPrivateRoomFailedAction?.Invoke();
     }
     #endregion


### PR DESCRIPTION
## Pull Request

### Description
Wasn't able to join room when between build and editor, now it is possible, also fix lobby connection when player failed to join a room

### Related Issue(s)
#21 

### Changes Made
Change automatic region selection to japan. It will evolve in the future. But now this is a kick solution.
Also player was disconnected from the lobby when failed to join a room, not anymore.

### Testing
Test done :
- Can create a room after failed to join one
- Can join room with a build outside of unity editor itself
- unit tests OK

### Screenshots (if applicable)

https://github.com/user-attachments/assets/df007161-ad81-4116-83ea-de0faaed4fc0

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Reviewer(s) (optional)
@PharaEthan tell me if anything wrong but now it should be fix.

### Definition of Done
The bug mentioned in the issue #21 is fix.