### PR TITLE
Issue #20 - Network Settings: fix allow customizable minimum player count for game start

### DIFF
--- a/Vermines/Assets/Resources/Network.meta
+++ b/Vermines/Assets/Resources/Network.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad1aa4ffb2f9abc4bb6ced3003cd6a7e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Resources/Network/Settings.meta
+++ b/Vermines/Assets/Resources/Network/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b00f264cb1318a3418e87b9c7992dc68
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Resources/Network/Settings/NetworkSettings.asset
+++ b/Vermines/Assets/Resources/Network/Settings/NetworkSettings.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59322f8f58a19e74a961a874ed9fb162, type: 3}
+  m_Name: NetworkSettings
+  m_EditorClassIdentifier: 
+  automaticallySyncScene: 1
+  maxPlayers: 4
+  minPlayers: 2
+  minPlayerNicknameLength: 4
+  maxPlayerNicknameLength: 8
+  maxRoomCodeLength: 4
+  minRoomCodeLength: 4
+  allowCustomRoomCodes: 1
+  defaultVisibleSetting: 0
+  keyStringCodeGeneration: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+  enableDebugLogging: 1

--- a/Vermines/Assets/Resources/Network/Settings/NetworkSettings.asset.meta
+++ b/Vermines/Assets/Resources/Network/Settings/NetworkSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49027826048902342b27fec51b668370
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Lobby/RoomManager.cs
+++ b/Vermines/Assets/Scripts/Lobby/RoomManager.cs
@@ -20,6 +20,26 @@ public class RoomManager : ARoomManager
     [SerializeField] private string _sceneToLoad;
     #endregion
 
+    #region Private Attributes
+    /*
+     * @brief This attribute is used to get the network settings.
+     */
+    private NetworkSettings _networkSettings;
+    #endregion
+
+    protected override void Awake()
+    {
+        base.Awake();
+
+        _networkSettings = Resources.Load<NetworkSettings>("Network/Settings/NetworkSettings");
+
+        if (_networkSettings == null)
+        {
+            Debug.LogError("NetworkSettings not found in Resources folder !");
+            return;
+        }
+    }
+
     /*
      * @brief This method is used to setup the code room input field before Update method is called the first time.
      * 
@@ -29,7 +49,7 @@ public class RoomManager : ARoomManager
      */
     void Start()
     {
-        _privateRoomCodeToJoin.characterLimit = 6;
+        _privateRoomCodeToJoin.characterLimit = _networkSettings.maxRoomCodeLength;
         _privateRoomCodeToJoin.contentType = TMP_InputField.ContentType.Password;
     }
 

--- a/Vermines/Assets/Scripts/Network/Lobby/NetworkLobbyManager.cs
+++ b/Vermines/Assets/Scripts/Network/Lobby/NetworkLobbyManager.cs
@@ -22,6 +22,10 @@ public class NetworkLobbyManager : MonoBehaviourPunCallbacks
     public event Action OnDisconnectedAction;
     #endregion
 
+    #region Private Attributes
+    private NetworkSettings _networkSettings;
+    #endregion
+
 
     #region Methods Implementation
     /*
@@ -31,6 +35,17 @@ public class NetworkLobbyManager : MonoBehaviourPunCallbacks
      * 
      * @return void
      */
+    private void Awake()
+    {
+        _networkSettings = Resources.Load<NetworkSettings>("Network/Settings/NetworkSettings");
+
+        if (_networkSettings == null)
+        {
+            Debug.LogError("NetworkSettings not found in Resources folder !");
+            return;
+        }
+    }
+
     public void ConnectClientToServer()
     {
         if (PhotonNetwork.IsConnectedAndReady)
@@ -81,7 +96,7 @@ public class NetworkLobbyManager : MonoBehaviourPunCallbacks
      */
     private void ConnectToLobby()
     {
-        PhotonNetwork.AutomaticallySyncScene = true;
+        PhotonNetwork.AutomaticallySyncScene = _networkSettings.automaticallySyncScene;
 
         if (PhotonNetwork.InLobby)
         {

--- a/Vermines/Assets/Scripts/Network/Lobby/NetworkLobbyManagerAssembly.asmdef
+++ b/Vermines/Assets/Scripts/Network/Lobby/NetworkLobbyManagerAssembly.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:831409e8f9d13b5479a3baef9822ad34",
         "GUID:57c32fc907df0f54e8e6e8f0d2488336",
-        "GUID:a738238285a7a8246af046cbf977522f"
+        "GUID:a738238285a7a8246af046cbf977522f",
+        "GUID:7c35a93390159514087b747380f61213"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Vermines/Assets/Scripts/Network/Room/NetworkRoomManager.cs
+++ b/Vermines/Assets/Scripts/Network/Room/NetworkRoomManager.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using System;
-using System.Linq;
 
 #region PUN2 Imports
 using Photon.Pun;
@@ -11,14 +10,9 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
 {
     #region Private Attributes
     /*
-     * @brief This string is used to generate a random code for the room.
+     * @brief This attribute is used to get the network settings.
      */
-    private const string keyStringCodeGeneration = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    
-    /*
-     * @brief This attribute is used to generate a random number.
-     */
-    private System.Random _random = new();
+    private NetworkSettings _networkSettings;
     #endregion
 
     #region Public Attributes
@@ -44,19 +38,30 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
     #endregion
 
     #region Methods Implementation
-    public void Start()
+    private void Awake()
     {
-        PhotonNetwork.NickName = "Player " + GenerateRandomCode(4);
+        _networkSettings = Resources.Load<NetworkSettings>("Network/Settings/NetworkSettings");
+
+        if (_networkSettings == null)
+        {
+            Debug.LogError("NetworkSettings not found in Resources folder !");
+            return;
+        }
+
+        PhotonNetwork.NickName = "Player " + NetworkUtils.GenerateRandomCode(_networkSettings.keyStringCodeGeneration,
+            _networkSettings.maxPlayerNicknameLength, _networkSettings.random);
     }
 
     /*
      * @brief This method is used to create a private room.
      * 
-     * @param void
+     * @param string roomCode (optional) default value is "".
+     * @param int? maxPLayers (optional) default value is null.
+     * @param bool? isVisible (optional) default value is null.
      * 
      * @return void
      */
-    public void CreatePrivateRoom(string roomCode = "", bool isVisible = false, int maxPLayers = 2)
+    public void CreatePrivateRoom(string roomCode = "", int? maxPLayers = null, bool? isVisible = null)
     {
         if (!PhotonNetwork.IsConnectedAndReady || !PhotonNetwork.InLobby || PhotonNetwork.InRoom)
         {
@@ -64,15 +69,31 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
             return;
         }
 
+        if (!_networkSettings.allowCustomRoomCodes && !string.IsNullOrEmpty(roomCode))
+        {
+            OnCreateRoomFailed(0, "Custom room codes are not allowed !");
+            return;
+        }
+
         if (string.IsNullOrEmpty(roomCode))
         {
-            roomCode = GenerateRandomCode(6);
+            roomCode = NetworkUtils.GenerateRandomCode(_networkSettings.keyStringCodeGeneration,
+                _networkSettings.maxRoomCodeLength, _networkSettings.random);
         }
+
+        if (maxPLayers != null && (maxPLayers < _networkSettings.minPlayers || maxPLayers > _networkSettings.maxPlayers))
+        {
+            OnCreateRoomFailed(0, "Invalid number of players !");
+            return;
+        }
+
+        maxPLayers ??= _networkSettings.maxPlayers;
+        isVisible ??= _networkSettings.defaultVisibleSetting;
 
         PhotonNetwork.CreateRoom(roomCode, new RoomOptions
         {
-            MaxPlayers = maxPLayers,
-            IsVisible = isVisible,
+            MaxPlayers = (int)maxPLayers,
+            IsVisible = (bool)isVisible,
         });
     }
 
@@ -85,26 +106,25 @@ public class NetworkRoomManager : MonoBehaviourPunCallbacks
      */
     public void JoinPrivateRoom(string roomCode)
     {
-        if (!PhotonNetwork.IsConnectedAndReady || !PhotonNetwork.InLobby || PhotonNetwork.InRoom || string.IsNullOrEmpty(roomCode))
+        if (!PhotonNetwork.IsConnectedAndReady || !PhotonNetwork.InLobby || PhotonNetwork.InRoom)
         {
             OnJoinRoomFailed(0, "Client not connected or already in a room !");
             return;
         }
 
-        PhotonNetwork.JoinRoom(roomCode);
-    }
+        if (string.IsNullOrEmpty(roomCode))
+        {
+            OnJoinRoomFailed(0, "Room code is empty !");
+            return;
+        }
 
-    /*
-     * @brief This method is used to generate a random code.
-     * 
-     * @param int length
-     * 
-     * @return string
-     */
-    public string GenerateRandomCode(int length)
-    {
-        return new string(Enumerable.Repeat(keyStringCodeGeneration, length).Select(s =>
-            s[_random.Next(0, keyStringCodeGeneration.Length)]).ToArray());
+        if (roomCode.Length < _networkSettings.minRoomCodeLength || roomCode.Length > _networkSettings.maxRoomCodeLength)
+        {
+            OnJoinRoomFailed(0, "Invalid room code length !");
+            return;
+        }
+
+        PhotonNetwork.JoinRoom(roomCode);
     }
 
     /*

--- a/Vermines/Assets/Scripts/Network/Settings.meta
+++ b/Vermines/Assets/Scripts/Network/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f84ee07e39856340ac803f95b65fc02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/Settings/NetworkSettings.cs
+++ b/Vermines/Assets/Scripts/Network/Settings/NetworkSettings.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+
+/*
+ * @breif This class is used to store the settings of the network.
+ * when instantiated it must be created in resources folder in network foler -> "ressources/network/". 
+ */
+[CreateAssetMenu(fileName = "NetworkSettings", menuName = "Network/Settings")]
+public class NetworkSettings : ScriptableObject
+{
+    /*
+     * @brief automaticallySyncScene is used to enable or disable the automatic synchronization of the scene.
+     */
+    public bool automaticallySyncScene = true;
+
+    /*
+     * @brief maxPlayers is used to store the maximum number of players in a room.
+     */
+    public int maxPlayers = 4;
+    /*
+     * @brief minPlayers is used to store the minimum number of players in a room.
+     */
+    public int minPlayers = 2;
+
+    /*
+     * @brief minPlayerNicknameLength is used to define the minimum length of the player nickname.
+     */
+    public int minPlayerNicknameLength = 4;
+    /*
+     * @brief maxPlayerNicknameLength is used to define the maximum length of the player nickname.
+     */
+    public int maxPlayerNicknameLength = 8;
+
+    /*
+     * @brief maxRoomCodeLength is used to define the maximum length of the room code, roomCode will automatically be generated using the max length.
+     */
+    public int maxRoomCodeLength = 8;
+    /*
+     * @brief minRoomCodeLength is used to define the minimum length of the room code.
+     */
+    public int minRoomCodeLength = 4;
+    /*
+     * @brief allowCustomRoomCodes is used to enable or disable custom room codes.
+     */
+    public bool allowCustomRoomCodes = true;
+    /*
+     * @brief defaultVisibleSetting is used to define the default visibility of the room, if false the room is "private" else "public".
+     */
+    public bool defaultVisibleSetting = false;
+
+    /*
+     * @brief keyStringCodeGeneration is used to store the key string to generate random codes.
+     */
+    public string keyStringCodeGeneration = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    /*
+     * @brief random is used to generate random numbers if needed.
+     */
+    public System.Random random = new();
+
+    /*
+     * @brief enableDebugLogging is used to enable or disable debug logging.
+     */
+    public bool enableDebugLogging = true;
+}

--- a/Vermines/Assets/Scripts/Network/Settings/NetworkSettings.cs.meta
+++ b/Vermines/Assets/Scripts/Network/Settings/NetworkSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59322f8f58a19e74a961a874ed9fb162
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/Settings/NetworkSettingsAssembly.asmdef
+++ b/Vermines/Assets/Scripts/Network/Settings/NetworkSettingsAssembly.asmdef
@@ -1,12 +1,8 @@
 {
-    "name": "NetworkRoomManagerAssembly",
+    "name": "NetworkSettingsAssembly",
     "rootNamespace": "",
     "references": [
-        "GUID:831409e8f9d13b5479a3baef9822ad34",
-        "GUID:57c32fc907df0f54e8e6e8f0d2488336",
-        "GUID:a738238285a7a8246af046cbf977522f",
-        "GUID:4d7f1c64c9ea01c4791eb6775dd950e0",
-        "GUID:7c35a93390159514087b747380f61213"
+        ""
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Vermines/Assets/Scripts/Network/Settings/NetworkSettingsAssembly.asmdef.meta
+++ b/Vermines/Assets/Scripts/Network/Settings/NetworkSettingsAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c35a93390159514087b747380f61213
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/Utils.meta
+++ b/Vermines/Assets/Scripts/Network/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0be4107ef19eb2a469b9595ceb89fe44
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/Utils/NetworkUtils.cs
+++ b/Vermines/Assets/Scripts/Network/Utils/NetworkUtils.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+
+public static class NetworkUtils
+{
+    public static string GenerateRandomCode(string keyStringCodeGeneration, int length, System.Random random)
+    {
+        if (length <= 0)
+        {
+            return string.Empty;
+        }
+
+        return new string(Enumerable.Repeat(keyStringCodeGeneration, length).Select(s =>
+            s[random.Next(0, keyStringCodeGeneration.Length)]).ToArray());
+    }
+}
+

--- a/Vermines/Assets/Scripts/Network/Utils/NetworkUtils.cs.meta
+++ b/Vermines/Assets/Scripts/Network/Utils/NetworkUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ed1c7ca3943b2846aecfc8085e57149
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/Utils/NetworkUtilsAssembly.asmdef
+++ b/Vermines/Assets/Scripts/Network/Utils/NetworkUtilsAssembly.asmdef
@@ -1,12 +1,8 @@
 {
-    "name": "NetworkRoomManagerAssembly",
+    "name": "NetworkUtilsAssembly",
     "rootNamespace": "",
     "references": [
-        "GUID:831409e8f9d13b5479a3baef9822ad34",
-        "GUID:57c32fc907df0f54e8e6e8f0d2488336",
-        "GUID:a738238285a7a8246af046cbf977522f",
-        "GUID:4d7f1c64c9ea01c4791eb6775dd950e0",
-        "GUID:7c35a93390159514087b747380f61213"
+        ""
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Vermines/Assets/Scripts/Network/Utils/NetworkUtilsAssembly.asmdef.meta
+++ b/Vermines/Assets/Scripts/Network/Utils/NetworkUtilsAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4d7f1c64c9ea01c4791eb6775dd950e0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/WaitingRoom/NetworkWaitingRoomAssembly.asmdef
+++ b/Vermines/Assets/Scripts/Network/WaitingRoom/NetworkWaitingRoomAssembly.asmdef
@@ -1,12 +1,11 @@
 {
-    "name": "NetworkRoomManagerAssembly",
+    "name": "NetworkWaitingRoomAssembly",
     "rootNamespace": "",
     "references": [
-        "GUID:831409e8f9d13b5479a3baef9822ad34",
-        "GUID:57c32fc907df0f54e8e6e8f0d2488336",
-        "GUID:a738238285a7a8246af046cbf977522f",
-        "GUID:4d7f1c64c9ea01c4791eb6775dd950e0",
-        "GUID:7c35a93390159514087b747380f61213"
+        "PhotonRealtime",
+        "PhotonUnityNetworking",
+        "NetworkUtilsAssembly",
+        "NetworkSettingsAssembly"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Vermines/Assets/Scripts/Network/WaitingRoom/NetworkWaitingRoomAssembly.asmdef.meta
+++ b/Vermines/Assets/Scripts/Network/WaitingRoom/NetworkWaitingRoomAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32433433a81a4064e98faeeb04f1f0bd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Network/WaitingRoom/NetworkWaitingRoomManager.cs
+++ b/Vermines/Assets/Scripts/Network/WaitingRoom/NetworkWaitingRoomManager.cs
@@ -22,15 +22,32 @@ public class NetworkWaitingRoomManager : MonoBehaviourPunCallbacks
      */
     public event Action OnPlayerEnteredRoomAction;
 
-
     /*
      * @brief This event is triggered when the master client can't start the match.
      */
     public event Action OnMasterCLientCantStartMatchAction;
+    #endregion
 
+    #region Private Attributes
+    /*
+     * @brief This attribute is used to get the network settings.
+     */
+    private NetworkSettings _networkSettings;
     #endregion
 
     #region Methods Implementation
+    private void Awake()
+    {
+        _networkSettings = Resources.Load<NetworkSettings>("Network/Settings/NetworkSettings");
+
+        if (_networkSettings == null)
+        {
+            Debug.LogError("NetworkSettings not found in Resources folder !");
+            return;
+        }
+    }
+
+
     /*
      * @brief This method is used to leave the waiting room.
      * 
@@ -126,13 +143,12 @@ public class NetworkWaitingRoomManager : MonoBehaviourPunCallbacks
      */
     public void LoadMatch(string levelName)
     {
-        if (PhotonNetwork.PlayerList.Length != PhotonNetwork.CurrentRoom.MaxPlayers)
+        if (PhotonNetwork.PlayerList.Length >= _networkSettings.minPlayers && PhotonNetwork.PlayerList.Length <= _networkSettings.maxPlayers)
         {
-            OnMasterClientCantStartMatch();
+            PhotonNetwork.LoadLevel(levelName);
             return;
-
         }
-        PhotonNetwork.LoadLevel(levelName);
+        OnMasterClientCantStartMatch();
     }
 
     #endregion
@@ -162,5 +178,4 @@ public class NetworkWaitingRoomManager : MonoBehaviourPunCallbacks
         Debug.Log("Master client failed to start the match !");
         OnMasterCLientCantStartMatchAction.Invoke();
     }
-
 }

--- a/Vermines/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Vermines/Assets/Tests/EditMode/EditMode.asmdef
@@ -12,7 +12,9 @@
         "CardEffect",
         "CardData",
         "Card",
-        "Deck"
+        "Deck",
+        "NetworkUtilsAssembly",
+        "NetworkSettingsAssembly"
     ],
     "includePlatforms": [
         "Editor"

--- a/Vermines/Assets/Tests/EditMode/NetworkRoomManagerTests.cs
+++ b/Vermines/Assets/Tests/EditMode/NetworkRoomManagerTests.cs
@@ -2,35 +2,38 @@ using NUnit.Framework;
 using UnityEngine;
 using System;
 using Photon.Pun;
+using UnityEngine.UIElements;
 
 [TestFixture]
 public class NetworkRoomManagerTests
 {
-    private NetworkRoomManager _networkRoomManager;
+    private NetworkSettings _networkSettings;
 
     [SetUp]
     public void Setup()
     {
-        // Create a GameObject and add the MonoBehaviour (NetworkRoomManager) to it
-        var gameObject = new GameObject();
-        _networkRoomManager = gameObject.AddComponent<NetworkRoomManager>();
+        _networkSettings = Resources.Load<NetworkSettings>("Network/Settings/NetworkSettings");
+
+        if (_networkSettings == null)
+        {
+            Debug.LogError("NetworkSettings not found in Resources folder !");
+            return;
+        }
     }
 
     [TearDown]
     public void Teardown()
     {
-        // Clean up the instantiated GameObject
-        GameObject.DestroyImmediate(_networkRoomManager.gameObject);
+        UnityEngine.Object.Destroy(_networkSettings);
     }
 
     [Test]
     public void GenerateRandomCode_ReturnsStringOfGivenLength()
     {
-        // Arrange
         int length = 6;
 
         // Act
-        string randomCode = _networkRoomManager.GenerateRandomCode(length);
+        string randomCode = NetworkUtils.GenerateRandomCode(_networkSettings.keyStringCodeGeneration, length, _networkSettings.random);
 
         // Assert
         Assert.AreEqual(length, randomCode.Length, "The generated code length is incorrect.");
@@ -39,17 +42,15 @@ public class NetworkRoomManagerTests
     [Test]
     public void GenerateRandomCode_ContainsOnlyAllowedCharacters()
     {
-        // Arrange
-        int length = 10;
-        string allowedCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        int length = 25;
 
         // Act
-        string randomCode = _networkRoomManager.GenerateRandomCode(length);
+        string randomCode = NetworkUtils.GenerateRandomCode(_networkSettings.keyStringCodeGeneration, length, _networkSettings.random);
 
         // Assert
         foreach (char c in randomCode)
         {
-            Assert.Contains(c, allowedCharacters.ToCharArray(), "Code contains invalid character.");
+            Assert.Contains(c, _networkSettings.keyStringCodeGeneration.ToCharArray(), "Code contains invalid character.");
         }
     }
 }


### PR DESCRIPTION
## Pull Request

### Description
This fix add a scriptable object able to configure some rooms settings, also add a network utils static class to avoid duplicate code, few changes in simple test to use utils.
Also add some verification for the scriptable object configuration
Able Players to start a game when not full in a room depending on the settings


### Related Issue(s)
Issue #20 

### Changes Made
- Add a scriptable object for network settings
- Adapt 2 unit tests
- Add some check depending on settings with the network
- Able player to start a game when not full in a room

### Testing
- Functional tests have been done
- Unit tests passed successfully

### Screenshots (if applicable)
![Capture d'écran 2024-10-17 114542](https://github.com/user-attachments/assets/5bf4201c-2aca-42b2-824a-2b91be4d2e90)
![Capture d'écran 2024-10-17 114605](https://github.com/user-attachments/assets/ebd8b1e2-6319-4c3c-87dc-9af10107edb7)
![Capture d'écran 2024-10-17 114612](https://github.com/user-attachments/assets/c647e78a-b243-459e-b82c-6af3be52695e)
![Capture d'écran 2024-10-17 114639](https://github.com/user-attachments/assets/2a1311be-851b-4141-bc0d-c787b8e97c48)
![Capture d'écran 2024-10-17 114705](https://github.com/user-attachments/assets/e6f50bdc-bad4-4953-914e-db4699d20f5e)
![Capture d'écran 2024-10-17 114746](https://github.com/user-attachments/assets/36f9c1e5-ac51-40f6-aeba-ebf9a5cae110)
![Capture d'écran 2024-10-17 114752](https://github.com/user-attachments/assets/0a263d9b-fbde-41e1-a97d-fea2ae31df7e)

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Reviewer(s) (optional)
@PharaEthan

### Definition of Done
Network is configurable using Scriptable Object
We can join a room even if it is not full
Unit tests passed successfully 