### PR TITLE
Issue 65: Add phase banner

### DIFF
--- a/Vermines/Assets/Resources/Prefabs/UI/HUD/Phase Banner.prefab
+++ b/Vermines/Assets/Resources/Prefabs/UI/HUD/Phase Banner.prefab
@@ -1,0 +1,265 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4830914215506196948
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2028731910178975094}
+  - component: {fileID: 7493906254937906746}
+  m_Layer: 5
+  m_Name: Phase Banner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2028731910178975094
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4830914215506196948}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 2661758736036539101}
+  - {fileID: 821313010924643439}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 548, y: 128}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &7493906254937906746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4830914215506196948}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a1c49b01b0ccb743abff1256f9fc21b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  phaseText: {fileID: 4906289514866184736}
+  currentPhase: 0
+--- !u!1 &5259390952148340018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 821313010924643439}
+  - component: {fileID: 6461922014495604943}
+  - component: {fileID: 4906289514866184736}
+  m_Layer: 5
+  m_Name: Texte
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &821313010924643439
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5259390952148340018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2028731910178975094}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 13.5}
+  m_SizeDelta: {x: 390, y: 48}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6461922014495604943
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5259390952148340018}
+  m_CullTransparentMesh: 1
+--- !u!114 &4906289514866184736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5259390952148340018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Phase de Sacrifice
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8189237380108376925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2661758736036539101}
+  - component: {fileID: 146262137318734989}
+  - component: {fileID: 3824798991200073943}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2661758736036539101
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189237380108376925}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 2028731910178975094}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 548, y: 128}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &146262137318734989
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189237380108376925}
+  m_CullTransparentMesh: 1
+--- !u!114 &3824798991200073943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189237380108376925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1c516e6928d0a8448891b312bbe059fc, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Vermines/Assets/Resources/Prefabs/UI/HUD/Phase Banner.prefab.meta
+++ b/Vermines/Assets/Resources/Prefabs/UI/HUD/Phase Banner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eb55402effb0b84438d25cb9f23122ee
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Resources/Scenes/UI.unity
+++ b/Vermines/Assets/Resources/Scenes/UI.unity
@@ -119,6 +119,165 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &8822078
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8822079}
+  m_Layer: 5
+  m_Name: Bottom Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8822079
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8822078}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1434051769}
+  m_Father: {fileID: 1548714564}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &413951857
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1685069021}
+    m_Modifications:
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 674
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 128
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2661758736036539101, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 674
+      objectReference: {fileID: 0}
+    - target: {fileID: 4830914215506196948, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+      propertyPath: m_Name
+      value: Phase Banner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+--- !u!1 &712640999 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4830914215506196948, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+  m_PrefabInstance: {fileID: 413951857}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &712641000 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2028731910178975094, guid: eb55402effb0b84438d25cb9f23122ee, type: 3}
+  m_PrefabInstance: {fileID: 413951857}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &950909588
 GameObject:
   m_ObjectHideFlags: 0
@@ -422,6 +581,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerListParent: {fileID: 950909589}
   playerBannerPrefab: {fileID: 4772245233492487442, guid: 3ee61d43e4175fa49996444f5273c7f4, type: 3}
+  phaseBannerObject: {fileID: 712640999}
+  buttonText: {fileID: 2036955056}
   debugMode: 1
 --- !u!4 &1295497003
 Transform:
@@ -451,7 +612,7 @@ GameObject:
   - component: {fileID: 1434051771}
   - component: {fileID: 1434051770}
   m_Layer: 5
-  m_Name: Button
+  m_Name: Phase Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -464,19 +625,19 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1434051768}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 2036955055}
-  m_Father: {fileID: 1548714564}
+  m_Father: {fileID: 8822079}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_SizeDelta: {x: 112, y: 112}
+  m_Pivot: {x: 1, y: 0}
 --- !u!114 &1434051770
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -523,7 +684,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1295497002}
         m_TargetAssemblyTypeName: Vermines.HUD.HUDManager, Vermines
-        m_MethodName: NextPlayer
+        m_MethodName: NextPhase
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -553,8 +714,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 80b9c9eb8ad600b439e060f307fbac21, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -758,7 +919,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1293773922}
-  - {fileID: 1434051769}
+  - {fileID: 8822079}
+  - {fileID: 1685069021}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -766,6 +928,42 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1685069020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1685069021}
+  m_Layer: 5
+  m_Name: Top
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1685069021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685069020}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 712641000}
+  m_Father: {fileID: 1548714564}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.75}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2036955054
 GameObject:
   m_ObjectHideFlags: 0

--- a/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/1.png.meta
+++ b/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/1.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -34,16 +34,16 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -100,7 +100,7 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/2.png.meta
+++ b/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/2.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -34,16 +34,16 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -100,7 +100,7 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/3.png.meta
+++ b/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/3.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -34,16 +34,16 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -100,7 +100,7 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/4.png.meta
+++ b/Vermines/Assets/Resources/Sprites/UI/Premium Pack v1.0/Premium Pack v1.0/2 Brown Book/1 Sprites/Paper UI Pack/Paper UI/Plain/2 Headers/4.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -34,16 +34,16 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -100,7 +100,7 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Vermines/Assets/Scripts/UI/HUD/PhaseBanner.cs
+++ b/Vermines/Assets/Scripts/UI/HUD/PhaseBanner.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+namespace Vermines.HUD
+{
+    public enum PhaseType
+    {
+        Sacrifice,
+        Gain,
+        Action,
+        Resolution
+    }
+
+    public class PhaseBanner : MonoBehaviour
+    {
+        [SerializeField] private TextMeshProUGUI phaseText; // Référence au composant Text de l'UI
+        [SerializeField] private PhaseType currentPhase; // Phase actuelle
+
+        // Appelé une fois avant la première exécution d'Update
+        void Start()
+        {
+            UpdatePhaseText();
+        }
+
+        // Méthode pour mettre à jour le texte affiché
+        public void SetPhase(PhaseType newPhase)
+        {
+            currentPhase = newPhase;
+            UpdatePhaseText();
+        }
+
+        private void UpdatePhaseText()
+        {
+            if (phaseText != null)
+            {
+                switch (currentPhase)
+                {
+                    case PhaseType.Sacrifice:
+                        phaseText.text = "Phase de Sacrifice";
+                        break;
+                    case PhaseType.Gain:
+                        phaseText.text = "Phase de Gain";
+                        break;
+                    case PhaseType.Action:
+                        phaseText.text = "Phase d'Action";
+                        break;
+                    case PhaseType.Resolution:
+                        phaseText.text = "Phase de Résolution";
+                        break;
+                    default:
+                        phaseText.text = "Phase Inconnue";
+                        break;
+                }
+            }
+            else
+            {
+                Debug.LogWarning("PhaseBanner: Le composant Text n'est pas assigné.");
+            }
+        }
+    }
+}

--- a/Vermines/Assets/Scripts/UI/HUD/PhaseBanner.cs.meta
+++ b/Vermines/Assets/Scripts/UI/HUD/PhaseBanner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a1c49b01b0ccb743abff1256f9fc21b

--- a/Vermines/Assets/Scripts/UI/HUD/PlayerBanner.cs
+++ b/Vermines/Assets/Scripts/UI/HUD/PlayerBanner.cs
@@ -10,12 +10,13 @@ namespace Vermines.HUD
         public TextMeshProUGUI playerEloquenceText;
         public TextMeshProUGUI playerSoulsText;
         public RectTransform rectTransform;
+        public float scale = 1.1f;
+        public float activeScale = 1.275f;
 
         private void Start()
         {
             if (playerNameObject != null)
             {
-                // get playerNameText parent
                 playerNameObject.SetActive(false);
             }
         }
@@ -38,7 +39,6 @@ namespace Vermines.HUD
 
         public void Setup(Player player)
         {
-            //playerNameText.text = player.Nickname;
             playerNameObject.GetComponent<TextMeshProUGUI>().text = player.Nickname;
             playerEloquenceText.text = player.Eloquence.ToString();
             playerSoulsText.text = player.Souls.ToString();
@@ -47,7 +47,7 @@ namespace Vermines.HUD
 
         public void SetSize(bool isActive)
         {
-            rectTransform.localScale = isActive ? Vector3.one * 1.275f : Vector3.one * 1.1f;
+            rectTransform.localScale = isActive ? Vector3.one * activeScale : Vector3.one * scale;
         }
     }
 }


### PR DESCRIPTION
## Pull Request

### Description

Creation of UI for phase:
- Add phase banner in canvas.
- Add phase manager to manipulate texts depends on the phase state.
- Add phase state enum.
- Add button to change phase, and when player end his turn, change player.

### Related Issue(s)

#65

### Changes Made

Add UI for phase changing, that allows player to see the state of the game.

### Testing

Manual testing.

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/70ed7900-0b75-4e99-be2a-294d621a73ea)
![image](https://github.com/user-attachments/assets/f09197e0-62d7-4852-bd8e-ed5133ace6d2)
![image](https://github.com/user-attachments/assets/5304e2a5-8a1e-4c51-b742-2ef230aecd7d)
![image](https://github.com/user-attachments/assets/6de91b9b-3157-42d0-838d-ea097280d285)
![image](https://github.com/user-attachments/assets/f3295889-63c8-4f09-aafc-dbcbb18157bf)
![image](https://github.com/user-attachments/assets/2e481ca6-286b-4711-96d0-cc7c32fb0a2b)
![image](https://github.com/user-attachments/assets/ce47cfb7-f811-4e47-bf2a-df9558f2e053)
![image](https://github.com/user-attachments/assets/69e15d9d-ed20-4a15-b9fb-be4f178fa1a8)

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
- [x] The banner/button change with the pahse state
- [x] The UI looks like the Figma