### PR TITLE
No ref: Upgrade 'upload-artifact' in the build worfklows

### DIFF
--- a/.github/workflows/unity_builder.yaml
+++ b/.github/workflows/unity_builder.yaml
@@ -91,7 +91,7 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: ${{ env.projectPath }}
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}
@@ -147,13 +147,13 @@ jobs:
           checkName: ${{ matrix.testMode }} Test Results
           coverageOption: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport'
       - name: Store test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.targetPlatform }}
           path: ${{ steps.tests.outputs.artifactsPath }}
       - name: Code Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.targetPlatform }}


### PR DESCRIPTION
## Pull Request

### Description

Currently, we were using the version 3 of 'upload-artifact', now we evolved to the version 4.

### Changes Made

Change every call of `actions/upload-artifact@v3` into `actions/upload-artifact@v4`

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
- [x] The worflow don't use deprecated version