### PR TITLE
Issue #173 - Phase Manager: fix ending phase calls

### DIFF
--- a/Vermines/Assets/Scripts/Gameplay/Logic/Phase/APhaseBase.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Logic/Phase/APhaseBase.cs
@@ -1,9 +1,8 @@
 ﻿using Fusion;
 
 namespace Vermines.Gameplay.Phases {
-
+    using UnityEngine;
     using Vermines.Gameplay.Phases.Enumerations;
-    using Vermines.Player;
 
     public interface IPhase {
 
@@ -26,16 +25,17 @@ namespace Vermines.Gameplay.Phases {
 
         /// <summary>
         /// Event that end the phase.
-        /// The logic value here represent if the function is called by the logic of the game or by the player.
-        /// - True: The function is called by the logic of the game.
-        /// - False: The function is called by the player.
+        /// The logic value here represent if the function is called by the logic of the game in trivial case, every player run this function with logic = ture.
+        /// - True: The function is called by the logic of the game, so every player run it.
+        /// - False: The function is called by the player, who the to play is.
         /// </summary>
-        /// <param name="logic">If the function is called by the logic of the game or by the player.</param>
+        /// <param name="logic">If the function is called by the logic of the game (every player) or just the current player to play</param>
         /// <param name="player">The player that end the phase.</param>
         public virtual void OnPhaseEnding(PlayerRef player, bool logic = false)
         {
+            Debug.Log($"[Server]: ({Type}) OnPhaseEnding by logic {logic} processing");
             if (logic == true) {
-                PhaseManager.Instance.RPC_PhaseCompleted();
+                PhaseManager.Instance.PhaseCompleted();
             } else {
                 GameEvents.OnAttemptNextPhase.Invoke();
             }

--- a/Vermines/Assets/Scripts/Gameplay/Logic/Phase/GainPhase.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Logic/Phase/GainPhase.cs
@@ -30,19 +30,15 @@ namespace Vermines.Gameplay.Phases {
         public override void Run(PlayerRef player)
         {
             _CurrentPlayer = player;
-
             ResetEveryEffectsThatWasActivatedDuringTheLastRound();
 
             Debug.Log($"Phase Gain is now running for player {_CurrentPlayer}");
 
             ExecuteCardEffect();
-
             ICommand earnCommand = new EarnCommand(_CurrentPlayer, GameManager.Instance.Config.NumberOfEloquencesToStartTheTurnWith.Value, DataType.Eloquence);
-
             CommandInvoker.ExecuteCommand(earnCommand);
 
             GameDataStorage.Instance.PlayerData.TryGet(_CurrentPlayer, out PlayerData playerData);
-
             GameEvents.OnPlayerUpdated.Invoke(playerData);
 
             if (_CurrentPlayer == PlayerController.Local.PlayerRef)

--- a/Vermines/Assets/Scripts/Gameplay/Logic/Phase/PhaseManager.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Logic/Phase/PhaseManager.cs
@@ -94,7 +94,7 @@ namespace Vermines.Gameplay.Phases {
 
         public void ProcessPhase(PhaseType currentPhase, PlayerRef playerRef)
         {
-            Debug.Log($"[SERVER]: Processing the phase for {playerRef}, currently playing {currentPhase}");
+            Debug.Log($"[SERVER]: Processing the phase for {playerRef} (Player Index: {GameManager.Instance.CurrentPlayerIndex}), currently playing {currentPhase}");
 
             _Phases[currentPhase].Run(playerRef);
         }
@@ -116,7 +116,6 @@ namespace Vermines.Gameplay.Phases {
 
                 RPC_UpdatePhaseUI();
             }
-
             RPC_ProcessPhase(CurrentPhase, GameManager.Instance.PlayerTurnOrder.Get(GameManager.Instance.CurrentPlayerIndex));
         }
 


### PR DESCRIPTION
## Pull Request

### Description
Please provide a brief summary of the changes and the purpose of this pull request.

### Related Issue(s)
Fix #173 

### Changes Made
- Change the phase manager to fix ending phase logic

### Testing
Hand tests

### Screenshots (if applicable)
N/A

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [ ] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Additional Notes (if any)
@EnzoGrn I added a todo in the sacrifice phase for you to hide the ui when we sacrified enough cards

### Reviewer(s) (optional)
N/A

### Definition of Done
We don't have turns skipping anymore