### PR TITLE
Issue #217 - Installer: add a configuration file 

### DIFF
--- a/Vermines.iss
+++ b/Vermines.iss
@@ -1,0 +1,47 @@
+; -----------------------------
+; Script Inno Setup for Vermines
+; -----------------------------
+
+[Setup]
+; Name display in the installer
+AppName=VerminesInstaller
+; Version display
+AppVersion=2.3.0
+; Company (facultatif)
+AppPublisher=OMGG
+; Website (facultatif)
+AppPublisherURL=http://91.134.33.129/
+
+; Default folder of the installation
+DefaultDirName={pf}\Vermines
+
+; Name of the output file (in OutputDir)
+OutputDir=.\Installer
+OutputBaseFilename=Vermines
+
+; Installer icon (optionnal)
+; SetupIconFile=Build\Vermines.ico
+
+Compression=zip
+SolidCompression=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+; Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+; Copy all Unity build files
+Source: "*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
+
+[Icons]
+; Shortcut in the starting menu
+Name: "{group}\Vermines"; Filename: "{app}\MonJeu.exe"
+
+; Desktop Shortcut (if enabled in options)
+Name: "{commondesktop}\Vermines"; Filename: "{app}\Vermines.exe"
+
+[Run]
+; Launche the game when installation end (optionnal)
+Filename: "{app}\Vermines.exe"; Description: "{cm:LaunchProgram,Vermines}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Pull Request

### Description

This pull-request add a configuration file for creating a Vermines Installer.

### Related Issue(s)

#217 

### Changes Made

Creating a new configuration file `Vermines.iss`.

### Testing

Launch the installer, install Vermines, launch it, and finally uninstall it.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Additional Notes (if any)

To open the `.iss` file, you need to download the [Inno Setup](https://jrsoftware.org/isdl.php) software.

Once installed, move the `.iss` file to the Vermines build and open it with Inno Setup.
Once opened, click on run script and wait for the installer to be created.

### Definition of Done
- [x] Installer can install the `Vermines.exe` and utility file
- [x] Installer add an Unistaller
- [x] `.iss` file can generate a Installer.