### PR TITLE
Issue #223 - Sacrifice Phase: skipping phase on client

### DIFF
--- a/Vermines/Assets/Scripts/Gameplay/Logic/Phase/SacrificePhase.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Logic/Phase/SacrificePhase.cs
@@ -108,7 +108,7 @@ namespace Vermines.Gameplay.Phases {
                 if (_NumberOfCardSacrified >= GameManager.Instance.SettingsData.MaxSacrificesPerTurn || cardCount == 0)
                 {
                     // Pop up context
-                    OnPhaseEnding(_CurrentPlayer, true);
+                    OnPhaseEnding(_CurrentPlayer, false);
                     GameplayUIController gameplayUIController = GameObject.FindAnyObjectByType<GameplayUIController>();
                     if (gameplayUIController != null)
                     {


### PR DESCRIPTION
## Pull Request

### Description
Fix skipping phase on every clients

### Related Issue(s)
#225 

### Changes Made
ligne 111: SacrificePhase
OnPhaseEnding(_CurrentPlayer, false);

### Testing
Hand tests has been done

### Screenshots (if applicable)
N/A

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Additional Notes (if any)
N/A

### Reviewer(s) (optional)
N/A

### Definition of Done
The phase skip correctly after sacrifiyng cards for non hosts