### PR TITLE
Issue #234 - Earn Phase: simulate equipment

### DIFF
--- a/Vermines/Assets/Editor/Vermines/Gameplay/Cards/Effects/Earn/EarnForEachEffectEditor.cs
+++ b/Vermines/Assets/Editor/Vermines/Gameplay/Cards/Effects/Earn/EarnForEachEffectEditor.cs
@@ -1,0 +1,38 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Vermines.Gameplay.Cards.Effect {
+
+    using Vermines.Editor.Gameplay.Cards.Effect;
+    using Vermines.CardSystem.Enumerations;
+
+    [CustomEditor(typeof(EarnForEachEffect))]
+    public class EarnForEachEffectEditor : AEffectEditor {
+
+        protected override void DrawCustomProperties()
+        {
+            if (target == null || target is not EarnForEachEffect)
+                return;
+            EarnForEachEffect effect = (EarnForEachEffect)target;
+
+            // -- [Header("Card Properties")]
+            GUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.LabelField("Effect Properties", EditorStyles.boldLabel);
+
+            effect.Amount = EditorGUILayout.IntField(new GUIContent("Amount", "The amount of data to earn."), effect.Amount);
+            effect.DataToEarn = (DataType)EditorGUILayout.EnumPopup(new GUIContent("Data type", "The type of the data you want to earn."), effect.DataToEarn);
+
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.HelpBox("Only Partisan and Equipment card types are supported.", MessageType.Warning);
+
+            GUILayout.BeginVertical(EditorStyles.helpBox);
+
+            effect.CardType = (CardType)EditorGUILayout.EnumPopup(new GUIContent("Card type", "The type of card to count."), effect.CardType);
+
+            GUILayout.EndVertical();
+            GUILayout.Space(10);
+            // -- EOF --
+        }
+    }
+}

--- a/Vermines/Assets/Editor/Vermines/Gameplay/Cards/Effects/Earn/EarnForEachEffectEditor.cs.meta
+++ b/Vermines/Assets/Editor/Vermines/Gameplay/Cards/Effects/Earn/EarnForEachEffectEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eb272d77165d37c4caaf89bd9fbe527d

--- a/Vermines/Assets/Resources/ScriptableObject/Effects/DaggerEffect.asset
+++ b/Vermines/Assets/Resources/ScriptableObject/Effects/DaggerEffect.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c266d1a9b5b782e41bb2f387658168af, type: 3}
   m_Name: DaggerEffect
   m_EditorClassIdentifier: 
-  _Type: 4
-  _Description: Earn <b><color=purple>1E</color></b> each time you play a <b>Partisan</b>
-    card.
-  _SubEffect: {fileID: 11400000, guid: 49b16af25acb7154d92dedeb27b64621, type: 2}
+  _Type: 0
+  _Description: Earn <b><color=purple>1E</color></b> for each <b>Partisan</b> card
+    played.
+  _SubEffect: {fileID: 11400000, guid: 8cac042ef1966bd4a8735b24c26c98ac, type: 2}

--- a/Vermines/Assets/Resources/ScriptableObject/Effects/EarnEffect/Earn1EForEachPartisanPlayed.asset
+++ b/Vermines/Assets/Resources/ScriptableObject/Effects/EarnEffect/Earn1EForEachPartisanPlayed.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f1a439dc52750f4f9b6fc93d25a0394, type: 3}
+  m_Name: Earn1EForEachPartisanPlayed
+  m_EditorClassIdentifier: 
+  _Description: Earn <b><color=purple>1E</color></b> for each <b>Partisan</b> card
+    played
+  _Amount: 1
+  _DataToEarn: 0
+  _CardType: 0
+  _SubEffect: {fileID: 0}
+  PartisanIcon: {fileID: 21300000, guid: 1f82901efd596d44daa5763f25078608, type: 3}
+  EquipmentIcon: {fileID: 21300000, guid: ab62db95797c5dd499082e5bbb83fc14, type: 3}
+  EloquenceIcon: {fileID: 21300000, guid: 4bfc719361e4f1f49a3001672b1d6bca, type: 3}
+  SoulIcon: {fileID: 21300000, guid: a3c4b0860b11f9145b70a7d40201e163, type: 3}
+  ThenIcon: {fileID: 21300000, guid: 24a76bff2862f8a4fbc25bf2c54630fa, type: 3}

--- a/Vermines/Assets/Resources/ScriptableObject/Effects/EarnEffect/Earn1EForEachPartisanPlayed.asset.meta
+++ b/Vermines/Assets/Resources/ScriptableObject/Effects/EarnEffect/Earn1EForEachPartisanPlayed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cac042ef1966bd4a8735b24c26c98ac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vermines/Assets/Scripts/Gameplay/Cards/Effects/EarnEffect/EarnForEach.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Cards/Effects/EarnEffect/EarnForEach.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Fusion;
+
+namespace Vermines.Gameplay.Cards.Effect {
+
+    using Vermines.CardSystem.Enumerations;
+    using Vermines.CardSystem.Data.Effect;
+    using Vermines.CardSystem.Elements;
+    using Vermines.Gameplay.Commands.Cards.Effects;
+    using OMGG.DesignPattern;
+
+    [CreateAssetMenu(fileName = "New Effect", menuName = "Vermines/Card System/Card/Effects/Earn/Earn data for each ...")]
+    public class EarnForEachEffect : AEffect {
+
+        #region Constants
+
+        private static readonly string template = "Earn {0} for each {1}";
+        private static readonly string eloquenceTemplate = "<b><color=purple>{0}E</color></b>";
+        private static readonly string soulTemplate = "<b><color=red>{0}A</color></b>";
+        private static readonly string partisanTemplate = "<b>Partisan</b> card played";
+        private static readonly string equipmentTemplate = "<b>Equipment</b> card";
+        private static readonly string linkerTemplate = " then ";
+
+        #endregion
+
+        #region Properties
+
+        [SerializeField]
+        private string _Description;
+
+        public override string Description
+        {
+            get => _Description;
+            set
+            {
+                _Description = value;
+            }
+        }
+
+        [SerializeField]
+        private int _Amount = 1;
+
+        public int Amount
+        {
+            get => _Amount;
+            set
+            {
+                _Amount = value;
+
+                UpdateDescription();
+            }
+        }
+
+        [SerializeField]
+        private DataType _DataToEarn = DataType.Eloquence;
+
+        public DataType DataToEarn
+        {
+            get => _DataToEarn;
+            set
+            {
+                _DataToEarn = value;
+
+                UpdateDescription();
+            }
+        }
+
+        [SerializeField]
+        private CardType _CardType = CardType.Partisan;
+
+        public CardType CardType
+        {
+            get => _CardType;
+            set
+            {
+                _CardType = value;
+
+                UpdateDescription();
+            }
+        }
+
+        [SerializeField]
+        private AEffect _SubEffect = null;
+
+        public override AEffect SubEffect
+        {
+            get => _SubEffect;
+            set
+            {
+                _SubEffect = value;
+
+                UpdateDescription();
+            }
+        }
+
+        #endregion
+
+        #region UI Elements
+
+        public Sprite PartisanIcon = null;
+        public Sprite EquipmentIcon = null;
+        public Sprite EloquenceIcon = null;
+        public Sprite SoulIcon = null;
+        public Sprite ThenIcon = null;
+
+        #endregion
+
+        public override void Play(PlayerRef player)
+        {
+            if (CardType == CardType.Equipment) {
+                List<ICard> equipments = GameDataStorage.Instance.PlayerDeck[player].Equipments;
+
+                foreach (ICard _ in equipments) {
+                    ICommand earnCommand = new EarnCommand(player, Amount, DataToEarn);
+
+                    CommandInvoker.ExecuteCommand(earnCommand);
+                }
+            } else if (CardType == CardType.Partisan) {
+                List<ICard> partisans = GameDataStorage.Instance.PlayerDeck[player].PlayedCards;
+
+                foreach (ICard _ in partisans) {
+                    ICommand earnCommand = new EarnCommand(player, Amount, DataToEarn);
+
+                    CommandInvoker.ExecuteCommand(earnCommand);
+                }
+            }
+
+            base.Play(player);
+        }
+
+        public override List<(string, Sprite)> Draw()
+        {
+            List<(string, Sprite)> elements = new();
+
+            if (DataToEarn == DataType.Eloquence) {
+                elements.Add(($"+{Amount}E", null));
+                elements.Add((null, EloquenceIcon));
+            } else if (DataToEarn == DataType.Soul) {
+                elements.Add(($"+{Amount}A", null));
+                elements.Add((null, SoulIcon));
+            }
+
+            elements.Add(("/", null));
+
+            if (CardType == CardType.Partisan) {
+                elements.Add((null, PartisanIcon));
+            } else if (CardType == CardType.Equipment) {
+                elements.Add((null, EquipmentIcon));
+            }
+
+            if (SubEffect != null) {
+                elements.Add((null, ThenIcon));
+                elements.AddRange(SubEffect.Draw());
+            }
+
+            return elements;
+        }
+
+        protected override void UpdateDescription()
+        {
+            string amountFormatted = "";
+
+            if (DataToEarn == DataType.Eloquence)
+                amountFormatted = string.Format(eloquenceTemplate, Amount);
+            else if (DataToEarn == DataType.Soul)
+                amountFormatted = string.Format(soulTemplate, Amount);
+
+            string target = "";
+            if (CardType == CardType.Partisan)
+                target = partisanTemplate;
+            else if (CardType == CardType.Equipment)
+                target = equipmentTemplate;
+
+            Description = string.Format(template, amountFormatted, target);
+
+            if (SubEffect != null) {
+                string subDescription = SubEffect.Description;
+
+                if (!string.IsNullOrEmpty(subDescription))
+                    subDescription = char.ToLower(subDescription[0]) + subDescription[1..];
+                Description += $"{linkerTemplate}{subDescription}";
+            }
+        }
+
+        private void OnEnable()
+        {
+            UpdateDescription();
+
+            if (PartisanIcon == null)
+                PartisanIcon = Resources.Load<Sprite>("Sprites/UI/Effects/Partisan_Card_Played");
+            if (EquipmentIcon == null)
+                EquipmentIcon = Resources.Load<Sprite>("Sprites/UI/Effects/Equipment_Card");
+            if (EloquenceIcon == null)
+                EloquenceIcon = Resources.Load<Sprite>("Sprites/UI/Icons/Eloquence");
+            if (SoulIcon == null)
+                SoulIcon = Resources.Load<Sprite>("Sprites/UI/Icons/Souls");
+            if (ThenIcon == null)
+                ThenIcon = Resources.Load<Sprite>("Sprites/UI/Effects/Then");
+        }
+
+        #region Editor Editor
+
+        public override void OnValidate()
+        {
+            UpdateDescription();
+        }
+
+        #endregion
+    }
+}

--- a/Vermines/Assets/Scripts/Gameplay/Cards/Effects/EarnEffect/EarnForEach.cs.meta
+++ b/Vermines/Assets/Scripts/Gameplay/Cards/Effects/EarnEffect/EarnForEach.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2f1a439dc52750f4f9b6fc93d25a0394

--- a/Vermines/Assets/Scripts/Gameplay/Logic/Phase/GainPhase.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Logic/Phase/GainPhase.cs
@@ -12,7 +12,6 @@ namespace Vermines.Gameplay.Phases {
     using Vermines.Gameplay.Phases.Enumerations;
     using Vermines.Player;
     using Vermines.UI;
-    using Vermines.UI.Plugin;
     using Vermines.UI.Screen;
 
     public class GainPhase : APhase {
@@ -36,8 +35,6 @@ namespace Vermines.Gameplay.Phases {
 
             ResetEveryEffectsThatWasActivatedDuringTheLastRound();
 
-            Debug.Log($"Phase Gain is now running for player {_CurrentPlayer}");
-
             ExecuteCardEffect();
 
             ICommand earnCommand = new EarnCommand(_CurrentPlayer, GameManager.Instance.SettingsData.NumberOfEloquencesEarnInGainPhase, DataType.Eloquence);
@@ -48,11 +45,10 @@ namespace Vermines.Gameplay.Phases {
 
             GameEvents.OnPlayerUpdated.Invoke(playerData);
 
-            if (_CurrentPlayer == PlayerController.Local.PlayerRef)
-            {
+            if (_CurrentPlayer == PlayerController.Local.PlayerRef) {
                 GameplayUIController gameplayUIController = GameObject.FindAnyObjectByType<GameplayUIController>();
-                if (gameplayUIController != null)
-                {
+
+                if (gameplayUIController != null) {
                     gameplayUIController.GetActiveScreen(out GameplayUIScreen lastScreen);
                     gameplayUIController.Show<GameplayUIGainSummary>(lastScreen);
                 }
@@ -61,37 +57,30 @@ namespace Vermines.Gameplay.Phases {
 
         private void ExecuteCardEffect()
         {
-            // TODO: Let the player interact with the effects of played cards.
+            List<ICard> equipmentCards = GameDataStorage.Instance.PlayerDeck[_CurrentPlayer].Equipments;
+            List<ICard> playedCards    = GameDataStorage.Instance.PlayerDeck[_CurrentPlayer].PlayedCards;
 
-            // Check if the effect is a passive effect or an active effect.
-
-            List<ICard> playedCards = GameDataStorage.Instance.PlayerDeck[_CurrentPlayer].PlayedCards;
-
-            Debug.Log($"[Client]: Player {_CurrentPlayer} has {playedCards.Count} played cards.");
-
-            foreach (ICard card in playedCards)
-            {
-                foreach (IEffect effect in card.Data.Effects)
-                {
-                    if (effect.Type == EffectType.Passive)
-                    {
+            foreach (ICard card in equipmentCards) {
+                foreach (IEffect effect in card.Data.Effects) {
+                    if (effect.Type == EffectType.Play) {
                         effect.Play(_CurrentPlayer);
-
-                        Debug.Log($"[Client]: Card {card.ID} is {card.Data.Name}, effect played");
                     }
                 }
             }
 
             foreach (ICard card in playedCards) {
-                foreach (AEffect effect in card.Data.Effects) {
-                    if (effect.Type == EffectType.Play) {
+                foreach (IEffect effect in card.Data.Effects) {
+                    if (effect.Type == EffectType.Passive)
                         effect.Play(_CurrentPlayer);
-
-                        Debug.Log($"[Client]: Card {card.ID} is {card.Data.Name}, effect played");
-                    }
                 }
             }
-            return;
+
+            foreach (ICard card in playedCards) {
+                foreach (AEffect effect in card.Data.Effects) {
+                    if (effect.Type == EffectType.Play)
+                        effect.Play(_CurrentPlayer);
+                }
+            }
         }
 
         public void OnEffectActivated(int cardID)


### PR DESCRIPTION
## Pull Request

### Description

This pull-request add to the earning phase, the simulation of equipment card.

### Related Issue(s)

#234

### Changes Made

- Add the list of equipment to the earning phase.

### Testing

Manual testing with several clients.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
- [x] Can simulate the equipment during the earning phase.