### PR TITLE
Hotfix 2.4.2

### DIFF
--- a/.github/workflows/game-builder.yaml
+++ b/.github/workflows/game-builder.yaml
@@ -177,7 +177,7 @@ jobs:
       - name: Get release version
         id: get_version
         run: | # Extract version number from the commit message, it must be in the format release-x.y.z, otherwise it will fail.
-          version=$(echo '${{ github.event.workflow_run.head_commit.message }}' | grep -oE '(release|hotfix)-[0-9]+\.[0-9]+\.[0-9]+' | sed -E 's/^(release|hotfix)-//')
+          version=$(echo '${{ github.event.workflow_run.head_commit.message }}' | grep -oE '(release|hotfix)-[0-9]+\.[0-9]+\.[0-9]+' | sed -E 's/^(release|hotfix)-//' | tr -d '\n' | tr -d '\r' | xargs)
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Download installer artifacts


### PR DESCRIPTION
### Description

Installer building error in workflows, because the project weight his to heavy.
The installer was not taking the good directory to build.

### Changes Made

- Change directory path to take when building the installer.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.