### PR TITLE
Hotfix 2.4.3

### DIFF
--- a/Vermines.iss
+++ b/Vermines.iss
@@ -10,13 +10,13 @@ AppVersion=2.3.0
 ; Company (facultatif)
 AppPublisher=OMGG
 ; Website (facultatif)
-AppPublisherURL=http://91.134.33.129/
+AppPublisherURL=https://omgg.fr/
 
 ; Default folder of the installation
 DefaultDirName={pf}\Vermines
 
 ; Name of the output file (in OutputDir)
-OutputDir=.\Installer
+OutputDir=build\Installer
 OutputBaseFilename=Vermines
 
 ; Installer icon (optionnal)
@@ -32,7 +32,6 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 ; Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Files]
-; Copie uniquement les fichiers du build Unity
 Source: "build\StandaloneWindows64\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
 
 [Icons]


### PR DESCRIPTION
### Description

Installer building error in workflows, because the project weight his to heavy.
The installer was not taking the good directory to build.

### Changes Made

- Change directory path to take when building the installer.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.