### PR TITLE
Issue #263 - UI: Skip earn phase with popup on close

### DIFF
--- a/Vermines/Assets/Scripts/System/CardSystem/Data/CardData.cs
+++ b/Vermines/Assets/Scripts/System/CardSystem/Data/CardData.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace Vermines.CardSystem.Data {
@@ -108,6 +108,15 @@ namespace Vermines.CardSystem.Data {
         }
 
         public bool ReduceInSilence = false;
+
+        public bool HasEffectOfType(EffectType type)
+        {
+            foreach (AEffect effect in Effects) {
+                if (effect.Type == type)
+                    return true;
+            }
+            return false;
+        }
 
         #endregion
 

--- a/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUIGainSummary.cs
+++ b/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUIGainSummary.cs
@@ -6,7 +6,7 @@ using UnityEngine.Localization;
 using Vermines.CardSystem.Enumerations;
 using Vermines.Gameplay.Phases;
 using Vermines.Player;
-using Vermines.ShopSystem.Enumerations;
+using Vermines.CardSystem.Elements;
 
 namespace Vermines.UI.Screen
 {
@@ -144,6 +144,16 @@ namespace Vermines.UI.Screen
         protected virtual void OnCloseButtonPressed()
         {
             Controller.Hide();
+
+            List<ICard> playedCards = GameDataStorage.Instance.PlayerDeck[PlayerController.Local.PlayerRef].PlayedCards;
+            if (playedCards.Find(c => c.Data.HasEffectOfType(EffectType.Activate)) == null)
+            {
+                GameEvents.OnAttemptNextPhase.Invoke();
+            }
+            else
+            {
+                Controller.Show<GameplayUITable>();
+            }
         }
 
         #endregion


### PR DESCRIPTION
### Description
This pull request links the close button behavior with the phase progression logic:
- When the player has no played card with an `Activate` effect, the game will automatically attempt to skip to the next phase.
- If the player has at least one played card with an `Activate` effect, the Gameplay UI Table is shown instead, allowing the player to interact with their effects.

This improves UX by removing unnecessary clicks when no interactive card is present.

### Related Issue(s)
Closes #263

### Changes Made
- Added a new utility method `HasEffectOfType(EffectType type)` in `CardData` to check for effect presence.
- Updated `GameplayUIGainSummary.OnCloseButtonPressed` logic:
  - Retrieve played cards from the player deck.
  - If no `Activate` effect is found, trigger `GameEvents.OnAttemptNextPhase`.
  - Otherwise, display the `GameplayUITable` again.

### Testing

- Manual Testing
  - Played turns with cards that include `Activate` effects → verified that UI table is shown instead of skipping.
  - Played turns without any `Activate` effects → verified that the phase auto-skips correctly.
  - Verified that closing the summary UI without played cards still behaves correctly.
- Automated Tests (if applicable)
  - Could be extended later to include a unit test for `HasEffectOfType`.

### Screenshots (if applicable)
_(Not applicable, no visual change — only UX flow improvement.)_

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Additional Notes (if any)
None.

### Reviewer(s) (optional)
None.

### Definition of Done
- The close button behavior correctly adapts to whether the player has played a card with an `Activate` effect.
- UX is streamlined (no redundant clicks when no activatable cards are played).
- Code respects existing architecture and conventions.
