### PR TITLE
Issue #283 - Discard: new logic for tools

### DIFF
--- a/Vermines/Assets/Scripts/Gameplay/Logic/Phase/ResolutionPhase.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Logic/Phase/ResolutionPhase.cs
@@ -1,10 +1,9 @@
 ﻿using OMGG.DesignPattern;
-using UnityEngine;
 using System.Linq;
 using Fusion;
 
 namespace Vermines.Gameplay.Phases {
-    using Vermines.CardSystem.Data;
+
     using Vermines.CardSystem.Data.Effect;
     using Vermines.CardSystem.Elements;
     using Vermines.CardSystem.Enumerations;
@@ -36,6 +35,9 @@ namespace Vermines.Gameplay.Phases {
                     GameEvents.OnShopRefilled.Invoke(shopSection.Key, shopSection.Value.AvailableCards.ToDictionary(x => x.Key, x => x.Value));
             }
 
+            // Merge the tool discards in the deck.
+            GameDataStorage.Instance.PlayerDeck[player].MergeToolDiscard(GameManager.Instance.SettingsData.Seed);
+
             // Refill Hand
             for (int i = 0; i < GameManager.Instance.SettingsData.NumberOfCardsToDrawAtEndOfTurn; i++) {
                 ICommand drawCardCommand = new DrawCommand(player);
@@ -53,10 +55,7 @@ namespace Vermines.Gameplay.Phases {
 
             // Clear the context manager
             if (UIContextManager.Instance != null)
-            {
                 UIContextManager.Instance.ClearContext();
-            }
-
             OnPhaseEnding(player, true); // Here true, because everyone know that the phase is over.
         }
 

--- a/Vermines/Assets/Scripts/Gameplay/Player/PlayerData.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Player/PlayerData.cs
@@ -51,6 +51,7 @@ namespace Vermines.Player {
         public List<ICard> Deck { get; set; }
         public List<ICard> Hand { get; set; }
         public List<ICard> Discard { get; set; }
+        public List<ICard> ToolDiscard { get; set; }
         public List<ICard> Graveyard { get; set; }
         public List<ICard> PlayedCards { get; set; }
         public List<ICard> Equipments { get; set; }
@@ -60,6 +61,7 @@ namespace Vermines.Player {
             Deck        = new List<ICard>();
             Hand        = new List<ICard>();
             Discard     = new List<ICard>();
+            ToolDiscard = new List<ICard>();
             Graveyard   = new List<ICard>();
             PlayedCards = new List<ICard>();
             Equipments  = new List<ICard>();
@@ -97,11 +99,23 @@ namespace Vermines.Player {
             
             if (card != null && Hand.Contains(card)) {
                 Hand.Remove(card);
-                Discard.Add(card);
 
+                if (card.Data.Type == CardType.Tools)
+                    ToolDiscard.Add(card);
+                else
+                    Discard.Add(card);
                 return card;
             }
+
             return null;
+        }
+
+        public void MergeToolDiscard(int seed)
+        {
+            if (ToolDiscard.Count > 0) {
+                Deck.Merge(ToolDiscard);
+                Deck.Shuffle(seed);
+            }
         }
 
         public ICard PlayCard(int cardId)
@@ -146,6 +160,7 @@ namespace Vermines.Player {
             serializedPlayerDeck += $"Deck[{string.Join(","        , Deck.Select(card        => card.ID))}]";
             serializedPlayerDeck += $";Hand[{string.Join(","       , Hand.Select(card        => card.ID))}]";
             serializedPlayerDeck += $";Discard[{string.Join(","    , Discard.Select(card     => card.ID))}]";
+            serializedPlayerDeck += $";ToolDiscard[{string.Join(",", ToolDiscard.Select(card => card.ID))}]";
             serializedPlayerDeck += $";Graveyard[{string.Join(","  , Graveyard.Select(card   => card.ID))}]";
             serializedPlayerDeck += $";PlayedCards[{string.Join(",", PlayedCards.Select(card => card.ID))}]";
             serializedPlayerDeck += $";Equipments[{string.Join("," , Equipments.Select(card  => card.ID))}]";
@@ -178,6 +193,10 @@ namespace Vermines.Player {
                     string content = deckSection[10..^1];
 
                     deck.Graveyard = CardSetDatabase.Instance.GetCardByIds(content);
+                } else if (deckSection.StartsWith("ToolDiscard[") && deckSection.EndsWith("]")) {
+                    string content = deckSection[12..^1];
+
+                    deck.ToolDiscard = CardSetDatabase.Instance.GetCardByIds(content);
                 } else if (deckSection.StartsWith("PlayedCards[") && deckSection.EndsWith("]")) {
                     string content = deckSection[12..^1];
 


### PR DESCRIPTION
### Description

This pull-request add the new discard rules concerning tools. Now when they are discarded they are add to a new deck 'ToolsDiscard', and merge during the resolution phase.

### Related Issue(s)

#283

### Changes Made

- `PlayerData`: Add the new deck, update serialization function. Create and update function to handle the new way of discard.
- `ResolutionPhase`: Merge the ToolsDiscard into the Deck and shuffle.

### Testing

Manual testing with 2 clients.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
- [x] Tools are added in a ToolsDiscard and merge during the Resolution phase.