### PR TITLE
hotfix-2.5.1

### DIFF
--- a/Vermines/Assets/Scripts/Configuration/GameSettingsData.cs
+++ b/Vermines/Assets/Scripts/Configuration/GameSettingsData.cs
@@ -60,7 +60,7 @@ namespace Vermines.Configuration.Network {
             );
         }
 
-        public readonly string ToString()
+        public override readonly string ToString()
         {
             return (
                 $"GameSettingsData(Seed: {Seed}, " +

--- a/Vermines/Assets/Scripts/Core/Networking/Networking.cs
+++ b/Vermines/Assets/Scripts/Core/Networking/Networking.cs
@@ -18,7 +18,6 @@ namespace Vermines.Core.Network {
     using Vermines.Core.Services;
     using Vermines.Menu.Matchmaking;
     using Vermines.Menu.View;
-    using static PlasticGui.PlasticTableColumn;
 
     public class Networking : MonoBehaviour {
 

--- a/Vermines/Assets/Scripts/Core/UI/UIBehaviour.cs
+++ b/Vermines/Assets/Scripts/Core/UI/UIBehaviour.cs
@@ -1,7 +1,6 @@
 using UnityEngine.UI;
 using UnityEngine;
 using TMPro;
-using UnityEditor.Animations;
 
 namespace Vermines.Core.UI {
 

--- a/Vermines/Assets/Scripts/Menu/CustomLobby/LobbyUIView.cs
+++ b/Vermines/Assets/Scripts/Menu/CustomLobby/LobbyUIView.cs
@@ -10,7 +10,6 @@ namespace Vermines.Menu.CustomLobby {
     using Vermines.Extension;
     using Vermines.Core;
     using Fusion;
-    using static PlasticGui.PlasticTableColumn;
 
     public class LobbyUIView : UIView {
 


### PR DESCRIPTION
### Description

This hotfix remove compilation error and warning.

### Changes Made

Remove Unity version control (Plastic SCM) dépend envies.
Remove unused editor imports.
Remove the différent warnings

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.
