### PR TITLE
Issue #320 - Fix: Replace player name with family name in turn banner

### DIFF
--- a/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUITurn.cs
+++ b/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUITurn.cs
@@ -59,7 +59,7 @@ namespace Vermines.UI.Screen
              if (currentPlayer == context.Runner.LocalPlayer)
                 LocalizeMessage("Turn.your");
             else
-                LocalizeMessage("Turn.text", player.Nickname);
+                LocalizeMessage("Turn.text", player.Statistics.Family.ToString());
 
             base.Show();
             ShowUser();


### PR DESCRIPTION
### Description
Replace player name with family name in turn banner.

### Related Issue(s)
Fix #320 

### Changes Made
- Replace player name with family name in turn banner

### Testing
Hand testing

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
Replace player name with family name in turn banner and it's correctly display
