### PR TITLE
Issue #330 - UI: fix ui in recycle when player doesn't have a card

### DIFF
--- a/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUIRecycle.cs
+++ b/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUIRecycle.cs
@@ -50,6 +50,8 @@ namespace Vermines.UI.Screen
         public override void Init()
         {
             base.Init();
+
+            _recycleHandler = new RecycleClickHandler();
         }
 
         /// <summary>
@@ -59,13 +61,13 @@ namespace Vermines.UI.Screen
         {
             base.Show();
 
-            _recycleHandler = new RecycleClickHandler();
             _recycleHandler.OnSelectionChanged += RefreshUI;
 
             List<GameObject> playerCards = PlayerController.Local.Context.HandManager.HandCards;
 
             // Get the previous click handler to restore it later
-            _previousClickHandler = playerCards[0].GetComponent<CardDisplay>().GetClickHandler();
+            if (playerCards.Count > 0)
+                _previousClickHandler = playerCards[0].GetComponent<CardDisplay>().GetClickHandler();
 
             foreach (var cardGO in playerCards)
             {


### PR DESCRIPTION
### Description
UI was stucked when player open it without cards.

### Related Issue(s)
Fix #330

### Changes Made
- Add an if to handle the case where player doesn't have a card

### Testing
Hand testing.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
Player can't be stuck now.
