### PR TITLE
Issue #330 - Recycle: Market UI

### DIFF
--- a/Vermines/Assets/Scripts/Gameplay/Commands/RecycleCommand.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Commands/RecycleCommand.cs
@@ -1,5 +1,5 @@
 using OMGG.DesignPattern;
-using Fusion;
+using UnityEngine;
 
 namespace Vermines.Gameplay.Commands {
 

--- a/Vermines/Assets/Scripts/Gameplay/Player/PlayerController.Response.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Player/PlayerController.Response.cs
@@ -96,7 +96,7 @@ namespace Vermines.Player {
         {
             ICard card = CardSetDatabase.Instance.GetCardByID(cardId);
 
-            if (!HasInputAuthority) {
+            if (!HasStateAuthority) {
                 ICommand cardSacrifiedCommand = new CLIENT_CardRecycleCommand(this, cardId, Context.GameplayMode.Shop.Sections[ShopType.Market]);
 
                 CommandInvoker.ExecuteCommand(cardSacrifiedCommand);

--- a/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUIRecycle.cs
+++ b/Vermines/Assets/Scripts/UI/HUD/Screens/GameplayUIRecycle.cs
@@ -130,7 +130,12 @@ namespace Vermines.UI.Screen
                 card.SetClickHandler(_previousClickHandler);
             }
             _recycleHandler.OnSelectionChanged -= RefreshUI;
+
             Controller.Hide();
+
+            cardCountText.text = "0";
+            eloquenceText.text = "0";
+            soulsText.text = "0";
         }
 
         #endregion


### PR DESCRIPTION
### Description

This pull-request remove recycling card duplication by the host, and refresh the UI in the market on every host and client.

### Related Issue(s)

#330

### Changes Made

- `PlayerController.Response` : Change `InputAuthority` into `StateAuthority`.
- `GameplayUIRecycle`: Reset text when closing the UI.

### Testing

Manuel testing with 2 clients.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.
