### PR TITLE
Issue #346 - Gameplay: Extra turn when someone reach 100 souls

### DIFF
--- a/Vermines/Assets/Scripts/Core/Gameplay/GameplayMode.cs
+++ b/Vermines/Assets/Scripts/Core/Gameplay/GameplayMode.cs
@@ -66,6 +66,12 @@ namespace Vermines.Core {
         [Networked]
         public int TotalTurnPlayed { get; set; } = 0;
 
+        [Networked]
+        public PlayerRef EndGameTriggerPlayer { get; set; } = PlayerRef.None;
+
+        [Networked]
+        public int EndGameTriggerTurn { get; set; }
+
         public ChronicleManager Announcer = new();
 
         private RoutineManager _RoutineManager;

--- a/Vermines/Assets/Scripts/Gameplay/Core/StandartGameplay.cs
+++ b/Vermines/Assets/Scripts/Gameplay/Core/StandartGameplay.cs
@@ -1,14 +1,14 @@
 using System.Collections.Generic;
-using OMGG.DesignPattern;
+using UnityEngine;
+using Fusion;
 
 namespace Vermines.Gameplay.Core {
+    using System.Linq;
     using Vermines.CardSystem.Data;
     using Vermines.CardSystem.Enumerations;
     using Vermines.Core;
     using Vermines.Player;
-    using Vermines.ShopSystem.Commands;
     using Vermines.ShopSystem.Enumerations;
-    using static System.Collections.Specialized.BitVector32;
 
     public partial class StandartGameplay : GameplayMode {
 
@@ -24,16 +24,22 @@ namespace Vermines.Gameplay.Core {
 
         protected override void CheckWinCondition()
         {
-            List<PlayerController> PlayersControllers = Context.Runner.GetAllBehaviours<PlayerController>();
+            List<PlayerController> players = Context.Runner.GetAllBehaviours<PlayerController>();
 
-            if (Context.NetworkGame == null || PlayersControllers == null)
+            if (Context.NetworkGame == null || players == null)
                 return;
-            foreach (PlayerController player in PlayersControllers) {
-                if (player == null)
-                    continue;
-                if (player.Statistics.Souls >= SoulsLimit) {
-                    FinishGameplay(player);
-                    return;
+            if (EndGameTriggerPlayer == PlayerRef.None) {
+                foreach (PlayerController player in players) {
+                    if (player == null)
+                        continue;
+                    if (player.Statistics.Souls >= SoulsLimit) {
+                        EndGameTriggerPlayer = player.Object.InputAuthority;
+                        EndGameTriggerTurn   = TotalTurnPlayed;
+
+                        Debug.Log($"End game triggered by {player.Nickname}");
+
+                        return;
+                    }
                 }
             }
         }
@@ -43,6 +49,16 @@ namespace Vermines.Gameplay.Core {
             base.FixedUpdateNetwork_Active();
 
             CheckWinCondition();
+
+            if (EndGameTriggerPlayer != PlayerRef.None) {
+                if (CurrentPlayer == EndGameTriggerPlayer && TotalTurnPlayed > EndGameTriggerTurn) {
+                    List<PlayerController> players = Context.Runner.GetAllBehaviours<PlayerController>();
+
+                    PlayerController winner = players.OrderByDescending(p => p.Statistics.Souls).ThenByDescending(p => p.Object.InputAuthority == EndGameTriggerPlayer).First();
+
+                    FinishGameplay(winner);
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
### Description

This pull request add a new end game rule to the game. Now when someone reach 100 souls, there is an extra turn for other player that have played less turn then him.

This gives them the opportunity to overtake the leading player and win the game during this additional turn.

### Related Issue(s)

#346

### Changes Made

- Change WinCondition in StandartGameplay.

### Testing

Manual testing with 2 clients. If the second player finish the game end, and the first player give an extra turn to the other player.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.